### PR TITLE
chore: release dde-application-wizard 0.1.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-wizard (0.1.1) unstable; urgency=medium
+
+  * Update translations
+
+ -- Wang Zichong <wangzichong@deepin.org>     Fri, 29 Dec 2023 15:10:00 +0800
+
 dde-application-wizard (0.1.0) unstable; urgency=medium
 
   * Release 0.1.0


### PR DESCRIPTION
Log:

集成后作为 launchpad 的依赖提供。解决 https://github.com/linuxdeepin/developer-center/issues/6655