### PR TITLE
chore: release dde-application-wizard 0.1.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-wizard (0.1.3) unstable; urgency=medium
+
+  * Adjust translation install location
+
+ -- Wang Zichong <wangzichong@deepin.org>     Thu, 04 Jan 2024 10:48:00 +0800
+
 dde-application-wizard (0.1.2) unstable; urgency=medium
 
   * Fix translation not loaded.


### PR DESCRIPTION
## 集成说明：

需要集成。

此集成所包括的软件包是提供老 AM 中卸载软件的接口的兼容服务。https://github.com/linuxdeepin/developer-center/issues/6655 也是因为在测试环境中缺少此兼容服务才导致卸载行为不工作的，此集成旨在确保仓库包含此包。

## 测试方式：

添加测试仓库后，手动安装 `dde-application-wizard-daemon-compat` 软件包。安装完毕后尝试在 launchpad 中卸载软件，检查是否可以卸载成功。

注意：考虑到 https://github.com/linuxdeepin/developer-center/issues/6700 仍然存在，目前测试前有个前置步骤需要做：

1. `sudo apt install packagekit`
2. `sudo pkcon search file a` （有输出即可）

## 回归 bug：

- https://github.com/linuxdeepin/developer-center/issues/6115