### PR TITLE
chore: allow dde-shell to uninstall app

### DIFF
--- a/dbus/launcher1compat.cpp
+++ b/dbus/launcher1compat.cpp
@@ -159,7 +159,7 @@ void Launcher1Compat::RequestUninstall(const QString & desktop, bool unused)
     procfile.close();
     qDebug() << cmdline;
 #ifndef QT_DEBUG
-    if (!QString(cmdline).endsWith(BINDIR_PREFIX + QStringLiteral("dde-launcher")) &&
+    if (!QString(cmdline).endsWith(BINDIR_PREFIX + QStringLiteral("dde-shell")) &&
         !QString(cmdline).endsWith(BINDIR_PREFIX + QStringLiteral("dde-launchpad"))) {
         qWarning() << cmdline << " has no right to uninstall " << desktop;
         return;


### PR DESCRIPTION
允许 dde-shell 进行卸载操作，同时不再允许 dde-launcher 进行卸载操作。

Issue: https://github.com/linuxdeepin/developer-center/issues/7823