### PR TITLE
feat: Adapt to uninstall of applications patched by deepin-deb-fix

### DIFF
--- a/dbus/launcher1compat.cpp
+++ b/dbus/launcher1compat.cpp
@@ -146,19 +146,26 @@ void Launcher1Compat::RequestUninstall(const QString & desktop, bool unused)
     }
 #endif // !QT_DEBUG
 
-    m_desktopFilePath = desktop;
+    // Adapt to deepin-deb-fix
+    if (desktop.startsWith("/usr/share/deepin-desktop-fix/applications/")) {
+        QFileInfo fixDesktopFileInfo(desktop);
+        m_desktopFilePath = "/usr/share/applications/" + fixDesktopFileInfo.fileName();
+        qDebug() << "Find fix desktop file: " << desktop << ", source file: " << m_desktopFilePath;
+    } else {
+        m_desktopFilePath = desktop;
+    }
 
     // Check if passed file is valid
-    QFileInfo desktopFileInfo(desktop);
+    QFileInfo desktopFileInfo(m_desktopFilePath);
     if (!desktopFileInfo.exists()) {
-        qDebug() << "File" << desktop << "doesn't exist.";
+        qDebug() << "File" << m_desktopFilePath << "doesn't exist.";
         return;
     }
 
-    QString desktopFilePath(desktopFileInfo.isSymLink() ? desktopFileInfo.symLinkTarget() : desktop);
+    QString desktopFilePath(desktopFileInfo.isSymLink() ? desktopFileInfo.symLinkTarget() : m_desktopFilePath);
     DDesktopEntry desktopEntry(desktopFilePath);
     if (desktopEntry.status() != DDesktopEntry::NoError) {
-        qDebug() << "Desktop file" << desktop << "is invalid.";
+        qDebug() << "Desktop file" << m_desktopFilePath << "is invalid.";
         return;
     }
 


### PR DESCRIPTION
Manually set the target desktop file to the source file patched by deep web fix during uninstallation

Issue: https://github.com/linuxdeepin/developer-center/issues/7885