### PR TITLE
chore: change pk policy from packagekit to appwiz's script

### DIFF
--- a/dbus/launcher1compat.cpp
+++ b/dbus/launcher1compat.cpp
@@ -121,7 +121,7 @@ void Launcher1Compat::uninstallPackageByScript(const QString & pkgDisplayName, c
     // call `/usr/libexec/dde-appwiz-uninstaller.sh <packageDesktopFilePath>` and check the return code.
     qDebug() << "Calling dde-appwiz-uninstaller.sh to uninstall" << pkgDisplayName << packageDesktopFilePath << "via script";
     QProcess process;
-    process.start("/usr/libexec/dde-appwiz-uninstaller.sh", QStringList{packageDesktopFilePath});
+    process.start("pkexec", QStringList{"/usr/libexec/dde-appwiz-uninstaller.sh", packageDesktopFilePath});
     process.waitForFinished();
 
     QString standardOutput = process.readAllStandardOutput();

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-application-wizard (0.1.14) unstable; urgency=medium
+
+  * chore: change polkit rule from packagekit to appwiz's script
+    (PMS: BUG-303279)
+
+ -- Wang Zichong <wangzichong@deepin.org>  Thu, 15 Mar 2025 20:00:00 +0800
+
 dde-application-wizard (0.1.13) unstable; urgency=medium
 
   * fix: Uninstalling compatibility mode application failed

--- a/polkit-1/rules.d/org.deepin.dde.application-wizard.rules
+++ b/polkit-1/rules.d/org.deepin.dde.application-wizard.rules
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 polkit.addRule(function(action, subject) {
-    if ((action.id == "org.freedesktop.packagekit.package-remove") &&
+    if ((action.id == "org.deepin.dde.appwiz.uninstall") &&
         subject.active == true && subject.local == true &&
         subject.isInGroup("sudo")) {
             return polkit.Result.YES;

--- a/scripts/dde-appwiz-uninstaller.sh
+++ b/scripts/dde-appwiz-uninstaller.sh
@@ -27,8 +27,15 @@ if [ -z "$PACKAGE_NAME" ]; then
     exit 1
 fi
 
+# Check if the user is root, if not, use pkexec
+if [ "$EUID" -eq 0 ]; then
+    apt_command="apt purge -y"
+else
+    apt_command="pkexec apt purge -y"
+fi
+
 # Use pkexec to uninstall the package
-if pkexec apt purge -y "$PACKAGE_NAME"; then
+if $apt_command "$PACKAGE_NAME"; then
     echo "Package '$PACKAGE_NAME' has been successfully uninstalled."
 else
     echo "Error: Failed to uninstall the package '$PACKAGE_NAME'."


### PR DESCRIPTION
调整卸载脚本的polkit规则,使得符合磐石环境的需求.

PMS: BUG-303279

## Summary by Sourcery

Modify the application uninstaller script and polkit rules to support non-root users uninstalling packages using pkexec

Bug Fixes:
- Improve package uninstallation mechanism to work correctly in Panshi (磐石) environment

Enhancements:
- Add root user check to dynamically choose between direct apt and pkexec-based uninstallation

Chores:
- Update uninstallation process to use pkexec for non-root users