### PR TITLE
fix: use ddeDisplayName instead of name for notifications

### DIFF
--- a/dbus/launcher1compat.cpp
+++ b/dbus/launcher1compat.cpp
@@ -213,18 +213,18 @@ void Launcher1Compat::RequestUninstall(const QString & desktop, bool unused)
         bool succ = uninstallLinglongBundle(desktopEntry);
         if (!succ) {
             emit UninstallFailed(desktopFilePath, QString());
-            sendNotification(desktopEntry.name(), false);
+            sendNotification(desktopEntry.ddeDisplayName(), false);
         } else {
             // FIXME: the filename of the desktop file MIGHT NOT be its desktopId in freedesktop spec.
             //        here is the logic from the legacy dde-application-manager which is INCORRECT in that case.
             QFileInfo fileInfo(desktopFilePath);
             postUninstallCleanUp(fileInfo.fileName());
             emit UninstallSuccess(desktopFilePath);
-            sendNotification(desktopEntry.name(), true);
+            sendNotification(desktopEntry.ddeDisplayName(), true);
         }
     // TODO: check if it's a flatpak or snap bundle and do the uninstallation?
     } else {
-        m_packageDisplayName = desktopEntry.name();
+        m_packageDisplayName = desktopEntry.ddeDisplayName();
 
         const QString compatibleDesktopJsonPath("/var/lib/deepin-compatible/compatibleDesktop.json");
         if (QFile::exists(compatibleDesktopJsonPath)) {


### PR DESCRIPTION
1. Changed desktopEntry.name() to desktopEntry.ddeDisplayName() for
uninstall notifications
2. Updated m_packageDisplayName assignment to use ddeDisplayName
3. This ensures consistent display names are shown in notifications
and UI
4. ddeDisplayName provides more user-friendly display names compared to
technical name field

fix: 使用 ddeDisplayName 替代 name 用于通知

1. 将 desktopEntry.name() 改为 desktopEntry.ddeDisplayName() 用于卸载
通知
2. 更新 m_packageDisplayName 赋值以使用 ddeDisplayName
3. 确保通知和界面中显示一致的名称
4. ddeDisplayName 提供比技术性 name 字段更用户友好的显示名称

pms: BUG-300263

## Summary by Sourcery

Replace technical desktopEntry.name() calls with user-friendly desktopEntry.ddeDisplayName() for uninstall notifications and package display name assignment to ensure consistent UI labels.

Bug Fixes:
- Use ddeDisplayName in sendNotification calls for both uninstall success and failure notifications
- Update m_packageDisplayName assignment to use ddeDisplayName