### PR TITLE
fix: pre-uninstall hook waitForFinished shouldn't timeout after 30s

### DIFF
--- a/dbus/launcher1compat.cpp
+++ b/dbus/launcher1compat.cpp
@@ -103,7 +103,7 @@ void Launcher1Compat::uninstallDCMPackage(const QString & pkgDisplayName, const 
     process.setProcessEnvironment(env);
     args.prepend("SUDO_USER=" + QString::fromLocal8Bit(qgetenv("USER")));
     args.prepend("env");
-    
+
     process.start("pkexec", args);
     process.waitForFinished();
     if (process.exitCode() != 0) {
@@ -195,8 +195,8 @@ void Launcher1Compat::RequestUninstall(const QString & desktop, bool unused)
             } else {
                 process.start(args[0], args.mid(1));
             }
-            process.waitForFinished();
-            if (process.exitCode() != 0) {
+            bool succ = process.waitForFinished(-1);
+            if (!succ || process.exitCode() != 0) {
                 qDebug() << "Pre-uninstall script" << preUninstallScript << "exited with exit code:" << process.exitCode() << process.error();
                 qDebug() << "stderr:" << process.readAllStandardError();
                 qDebug() << "stdout:" << process.readAllStandardOutput();
@@ -238,7 +238,7 @@ void Launcher1Compat::RequestUninstall(const QString & desktop, bool unused)
             //     "environment-name2-package-name2": {...},
             //     ...
             // }
-            // Check if desktopFilePath's file name (without `.desktop` suffix) is in the json file. If so, execute the 
+            // Check if desktopFilePath's file name (without `.desktop` suffix) is in the json file. If so, execute the
             // RemoveCommand via `pkexec`.
             QFile jsonFile(compatibleDesktopJsonPath);
             if (jsonFile.open(QIODevice::ReadOnly | QIODevice::Text)) {


### PR DESCRIPTION
避免 `QProcess::waitForFinished` 默认的超时行为导致脚本未执行完即进行后续的卸载步骤。对方的卸载脚本内可能包含询问用户是否卸载的对话框，用户可能会在这个界面停止操作。

## Summary by Sourcery

Allow pre-uninstall hooks to run without a hard 30s timeout and fail gracefully if they don’t finish successfully

Bug Fixes:
- Use waitForFinished(-1) instead of the default timeout to let pre-uninstall scripts complete
- Check the return value of waitForFinished and treat a timeout or failure as an error before proceeding with uninstallation