### PR TITLE
fix: add hardening compiler flags in Debian build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,9 @@ export QT_SELECT=5
 
 # see FEATURE AREAS in dpkg-buildflags(1)
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 # see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS


### PR DESCRIPTION
1. Added DEB_CFLAGS_MAINT_APPEND with -Wall for warning flags
2. Added DEB_CXXFLAGS_MAINT_APPEND with -Wall for C++ warnings
3. Added extensive DEB_LDFLAGS_MAINT_APPEND with security hardening flags:
   - --as-needed for linker optimization
   - -z,relro for RELRO protection
   - -z,now for immediate binding
   - -z,noexecstack for stack protection
   - -E for exporting symbols

These changes improve security hardening during package build by enabling additional compiler warnings and linker security features recommended for Debian packages.

fix: 在 Debian 构建中添加加固编译标志

1. 添加 DEB_CFLAGS_MAINT_APPEND 包含 -Wall 警告标志
2. 添加 DEB_CXXFLAGS_MAINT_APPEND 包含 C++ 警告标志
3. 添加全面的 DEB_LDFLAGS_MAINT_APPEND 安全加固标志:
   - --as-needed 用于链接器优化
   - -z,relro 用于 RELRO 保护
   - -z,now 用于立即绑定
   - -z,noexecstack 用于栈保护
   - -E 用于导出符号

这些更改通过在包构建过程中启用额外的编译器警告和链接器安全功能来提高安全
性，这些是 Debian 包推荐的安全加固措施。

## Summary by Sourcery

Enable Debian build hardening by appending compiler warning and linker security flags

Build:
- Append -Wall to DEB_CFLAGS_MAINT_APPEND and DEB_CXXFLAGS_MAINT_APPEND to enable C/C++ compiler warnings
- Add DEB_LDFLAGS_MAINT_APPEND with --as-needed, -z relro, -z now, -z noexecstack, and -E for linker security hardening