### PR TITLE
chore: bump version to 0.1.16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-wizard (0.1.16) unstable; urgency=medium
+
+  * fix: pre-uninstall hook waitForFinished shouldn't timeout after 30s
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 03 Jul 2025 17:13:02 +0800
+
 dde-application-wizard (0.1.15) unstable; urgency=medium
 
   * fix: use ddeDisplayName instead of name for notifications


### PR DESCRIPTION
update changelog to 0.1.16

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 0.1.16 bump