### PR TITLE
chore: bump version to 0.1.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-wizard (0.1.17) unstable; urgency=medium
+
+  * fix: add hardening compiler flags in Debian build
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 03 Jul 2025 19:52:26 +0800
+
 dde-application-wizard (0.1.16) unstable; urgency=medium
 
   * fix: pre-uninstall hook waitForFinished shouldn't timeout after 30s


### PR DESCRIPTION
update changelog to 0.1.17

## Summary by Sourcery

Chores:
- Bump Debian changelog version to 0.1.17.