### PR TITLE
refactor: make RequestUninstall not queued

### DIFF
--- a/dbus/launcher1compat.h
+++ b/dbus/launcher1compat.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,8 +7,12 @@
 #include <QDBusContext>
 #include <QDBusMessage>
 #include <QObject>
+#include <QThreadPool>
+#include <QRunnable>
 
 class Launcher1Adaptor;
+class UninstallTask;
+
 class Launcher1Compat : public QObject, protected QDBusContext
 {
     Q_OBJECT
@@ -31,14 +35,26 @@ signals:
 private:
     explicit Launcher1Compat(QObject *parent = nullptr);
 
-    void uninstallPackageKitPackage(const QString & pkgDisplayName, const QString & pkPackageId);
-    void uninstallDCMPackage(const QString & pkgDisplayName, const QString & uninstallCmd);
-    void uninstallPackageByScript(const QString & pkgDisplayName, const QString & packageDesktopFilePath);
-
     Launcher1Adaptor * m_daemonLauncher1Adapter;
+};
 
-    // TODO: vvv This is bad, refactor this later vvv
-    QString m_packageDisplayName;
+class UninstallTask : public QObject, public QRunnable
+{
+    Q_OBJECT
+public:
+    explicit UninstallTask(const QString &desktop, Launcher1Compat *parent);
+    void run() override;
+
+signals:
+    void uninstallFailed(const QString &appId, const QString &errMsg);
+    void uninstallSuccess(const QString &appID);
+
+private:
+    void uninstallPackageKitPackage(const QString & pkgDisplayName, const QString & pkPackageId, const QString & desktopFilePath);
+    void uninstallDCMPackage(const QString & pkgDisplayName, const QString & uninstallCmd, const QString & desktopFilePath);
+    void uninstallPackageByScript(const QString & pkgDisplayName, const QString & packageDesktopFilePath);
+    void finishTask();
+
     QString m_desktopFilePath;
-    // TODO: ^^^ -------------------------------- ^^^
+    Launcher1Compat *m_parent;
 };


### PR DESCRIPTION
wine 卸载钩子的需求是，允许触发多个卸载请求，若钩子脚本的返回值是 103 则认为是存在正在运行的钩子实例，直接拒绝后续卸载，是 101 则认为是用户主动取消了卸载行为。其余返回这均需要正常执行后续的卸载行为。

因此进行相应调整，使用 QThreadPool 允许多个卸载行为并行执行，并增加卸载钩子的返回值判断。

## Summary by Sourcery

Migrate uninstall logic into a QRunnable UninstallTask class and dispatch it via a QThreadPool to support up to 5 parallel uninstall operations, while adding return-code-based handling for pre-uninstall hooks to control cancellation or conflicts.

New Features:
- Support multiple concurrent uninstall requests using QThreadPool

Enhancements:
- Emit unified uninstallSuccess and uninstallFailed signals for all uninstall paths