### PR TITLE
chore: able to mark if we should skip preuninstall hook

### DIFF
--- a/dbus/launcher1compat.cpp
+++ b/dbus/launcher1compat.cpp
@@ -140,10 +140,8 @@ void Launcher1Compat::uninstallPackageByScript(const QString & pkgDisplayName, c
 }
 
 // the 1st argument is the full path of a desktop file.
-void Launcher1Compat::RequestUninstall(const QString & desktop, bool unused)
+void Launcher1Compat::RequestUninstall(const QString & desktop, bool skipPreinstallHook)
 {
-    Q_UNUSED(unused)
-
     // TODO: If we go with packagekit, it will ask user to input the password to uninstall application.
     //       Thus this checking will be no longer necessary. We still need this check since we are
     //       still using lastore to uninstall package if it exists.
@@ -175,7 +173,7 @@ void Launcher1Compat::RequestUninstall(const QString & desktop, bool unused)
         return;
     }
 
-    if (!desktopEntry.stringValue("X-Deepin-PreUninstall").isEmpty()) {
+    if (!skipPreinstallHook && !desktopEntry.stringValue("X-Deepin-PreUninstall").isEmpty()) {
         QFileInfo desktopFileInfo(desktopFilePath);
         bool writable = desktopFileInfo.isWritable();
         if (writable) {

--- a/dbus/launcher1compat.h
+++ b/dbus/launcher1compat.h
@@ -22,7 +22,7 @@ public:
 
 // Launcher1Adapter
 public:
-    void RequestUninstall(const QString &desktop, bool unused);
+    void RequestUninstall(const QString &desktop, bool skipPreinstallHook);
 
 signals:
     void UninstallFailed(const QString &appId, const QString &errMsg);


### PR DESCRIPTION
根据 wine 一侧需求，卸载前钩子需要并行调用，但根据启动器的卸载需求，
卸载行为应当串行队列形式依次进行。当前卸载逻辑过于繁杂，不便迅速做
出修改。

受限于时间，暂时让启动器来执行卸载钩子，待后续再调整回由卸载服务进行
调用。

此修改利用原本未被使用的第二个 dbus 参数标记是否应当跳过卸载前钩子，
以便提供一定程度上的兼容。

相关：

- https://github.com/linuxdeepin/dde-application-wizard/pull/46

## Summary by Sourcery

Enhancements:
- Rename the second D-Bus argument in RequestUninstall to skipPreinstallHook and use it to conditionally bypass the pre-uninstall hook