### PR TITLE
chore: bump version to 0.1.18

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-wizard (0.1.18) unstable; urgency=medium
+
+  * chore: able to mark if we should skip preuninstall hook
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 10 Jul 2025 20:15:27 +0800
+
 dde-application-wizard (0.1.17) unstable; urgency=medium
 
   * fix: add hardening compiler flags in Debian build


### PR DESCRIPTION
update changelog to 0.1.18

## Summary by Sourcery

Chores:
- Bump Debian package version to 0.1.18 in changelog