### PR TITLE
feat: add user-level desktop file handling in uninstaller

### DIFF
--- a/dbus/launcher1compat.cpp
+++ b/dbus/launcher1compat.cpp
@@ -10,6 +10,9 @@
 #include <DNotifySender>
 #include <launcher1adaptor.h> // this is the adapter of daemon.Launcher1
 
+// Qt includes
+#include <QSet>
+
 // PackageKit-Qt
 #include <Daemon>
 
@@ -166,7 +169,41 @@ void Launcher1Compat::RequestUninstall(const QString & desktop, bool skipPreinst
         return;
     }
 
-    QString desktopFilePath(desktopFileInfo.isSymLink() ? desktopFileInfo.symLinkTarget() : desktop);
+    QString desktopFilePath;
+    if (desktopFileInfo.isSymLink()) {
+        // Recursively resolve symlinks to get the final target
+        QString currentPath = desktop;
+        QSet<QString> visitedPaths; // Prevent infinite loops
+        
+        while (true) {
+            QFileInfo currentInfo(currentPath);
+            if (!currentInfo.isSymLink()) {
+                // Found the final target
+                desktopFilePath = currentPath;
+                break;
+            }
+            
+            QString symLinkTarget = currentInfo.symLinkTarget();
+            if (!QFile::exists(symLinkTarget)) {
+                qDebug() << "Symlink target" << symLinkTarget << "does not exist, using original path" << desktop;
+                desktopFilePath = desktop;
+                break;
+            }
+            
+            if (visitedPaths.contains(currentPath)) {
+                qDebug() << "Circular symlink detected, using original path" << desktop;
+                desktopFilePath = desktop;
+                break;
+            }
+            
+            visitedPaths.insert(currentPath);
+            currentPath = symLinkTarget;
+        }
+        
+        qDebug() << "Resolved symlink chain from" << desktop << "to" << desktopFilePath;
+    } else {
+        desktopFilePath = desktop;
+    }
     DDesktopEntry desktopEntry(desktopFilePath);
     if (desktopEntry.status() != DDesktopEntry::NoError) {
         qDebug() << "Desktop file" << desktop << "is invalid.";
@@ -221,6 +258,40 @@ void Launcher1Compat::RequestUninstall(const QString & desktop, bool skipPreinst
             sendNotification(desktopEntry.ddeDisplayName(), true);
         }
     // TODO: check if it's a flatpak or snap bundle and do the uninstallation?
+    // 单独处理chrome 的快捷浏览器创建卸载
+    } else if (desktopFilePath.contains("/.local/share/applications/") && 
+               (desktopFilePath.contains("chrome-") || 
+                desktopEntry.stringValue("Exec").contains("google-chrome"))) {
+        // Handle Chrome PWA apps specifically
+        qDebug() << "Detected Chrome PWA application:" << desktopFilePath;
+        
+        bool success = true;
+        QString iconPath = desktopEntry.stringValue("Icon");
+        
+        // Remove the desktop file
+        QFile desktopFile(desktopFilePath);
+        if (!desktopFile.remove()) {
+            qDebug() << "Failed to remove Chrome PWA desktop file:" << desktopFilePath;
+            success = false;
+        }
+        
+        // Remove the associated icon if it's a file path
+        if (success && !iconPath.isEmpty() && QFile::exists(iconPath)) {
+            QFile iconFile(iconPath);
+            if (!iconFile.remove()) {
+                qDebug() << "Warning: Failed to remove Chrome PWA icon file:" << iconPath;
+            }
+        }
+        
+        if (success) {
+            QFileInfo fileInfo(desktopFilePath);
+            postUninstallCleanUp(fileInfo.fileName());
+            emit UninstallSuccess(desktopFilePath);
+            sendNotification(desktopEntry.ddeDisplayName(), true);
+        } else {
+            emit UninstallFailed(desktopFilePath, QString("Failed to remove Chrome PWA application"));
+            sendNotification(desktopEntry.ddeDisplayName(), false);
+        }
     } else {
         m_packageDisplayName = desktopEntry.ddeDisplayName();
 


### PR DESCRIPTION
1. Added special handling for user-level desktop files (in ~/.local/ share/applications/)
2. Automatically removes both the desktop file and associated icon if found
3. Provides clear success/error messages for user feedback
4. Maintains existing system-wide desktop file handling logic
5. Improves cleanup of user-installed applications

feat: 在卸载程序中添加用户级桌面文件处理

1. 添加了对用户级桌面文件（位于~/.local/share/applications/）的特殊处理
2. 自动删除桌面文件及关联图标（如果找到）
3. 提供清晰的成功/错误信息作为用户反馈
4. 保留现有的系统级桌面文件处理逻辑
5. 改进用户安装应用程序的清理工作

Pms: BUG-315791

## Summary by Sourcery

Add special handling to the uninstaller for user-level desktop files by detecting and removing them along with any associated icons, while preserving existing system-wide logic and enhancing cleanup of user-installed applications

New Features:
- Detect and remove user-level desktop files under ~/.local/share/applications
- Automatically remove associated icon files referenced in the desktop file
- Display clear success and error messages during user-level file removal

Enhancements:
- Retain existing system-wide desktop file handling logic
- Improve cleanup of user-installed applications