### PR TITLE
feat: add application icon support for uninstall notifications

### DIFF
--- a/dbus/launcher1compat.h
+++ b/dbus/launcher1compat.h
@@ -40,5 +40,6 @@ private:
     // TODO: vvv This is bad, refactor this later vvv
     QString m_packageDisplayName;
     QString m_desktopFilePath;
+    QString m_base64Icon;
     // TODO: ^^^ -------------------------------- ^^^
 };


### PR DESCRIPTION
Added QIcon to base64 conversion function to extract application icons from desktop files
Modified sendNotification to accept icon parameter and use app-specific icons instead of default
Implemented icon extraction in RequestUninstall method to get proper app icon from desktop entry
This provides better user experience by showing the actual application icon in uninstall notifications

feat: 为卸载通知添加应用程序图标支持

添加了QIcon到base64的转换函数以从桌面文件中提取应用程序图标
修改sendNotification以接受图标参数并使用应用特定图标而非默认图标
在RequestUninstall方法中实现图标提取功能以从桌面条目获取正确的应用图标
通过在实际卸载通知中显示应用程序图标来提供更好的用户体验

Pms: BUG-271633

## Summary by Sourcery

Add application icon support for uninstall notifications by extracting icons from desktop entries and converting them to base64 data URIs, then updating notification sending to use these icons.

New Features:
- Introduce qIconToBase64 function to convert QIcon objects to base64-encoded PNG data URIs
- Extend sendNotification to accept a custom icon parameter and apply it to uninstall notifications
- Fetch and convert the application’s theme icon from desktop entries in RequestUninstall to display the correct icon