### PR TITLE
chore: bump version to 0.1.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-application-wizard (0.1.19) unstable; urgency=medium
+
+  * feat: add application icon support for uninstall notifications
+
+ -- wujiangyu <wujiangyu@uniontech.com>  Thu, 21 Aug 2025 17:25:17 +0800
+
 dde-application-wizard (0.1.18) unstable; urgency=medium
 
   * chore: able to mark if we should skip preuninstall hook


### PR DESCRIPTION
update changelog to 0.1.19

## Summary by Sourcery

Build:
- Update debian/changelog to version 0.1.19 with the new release date