### PR TITLE
feat: add Linglong uninstaller script support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
 
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
 install(FILES scripts/dde-appwiz-uninstaller.sh DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
+install(FILES scripts/dde-appwiz-linglong-uninstaller.sh DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
 install(FILES polkit-1/actions/org.deepin.dde.appwiz.uninstall.policy DESTINATION ${CMAKE_INSTALL_DATADIR}/polkit-1/actions)
 install(FILES polkit-1/rules.d/org.deepin.dde.application-wizard.rules DESTINATION ${CMAKE_INSTALL_DATADIR}/polkit-1/rules.d)
 install(FILES ${TRANSLATED_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/dde-application-wizard/translations)

--- a/dbus/launcher1compat.cpp
+++ b/dbus/launcher1compat.cpp
@@ -85,11 +85,12 @@ void sendNotification(const QString & displayName, bool successed, const QString
 bool uninstallLinglongBundle(const DDesktopEntry & entry)
 {
     const QString appId = entry.rawValue("Exec").section(' ', 2, 2);
-    const QStringList args {"uninstall", appId};
     QProcess process;
-
-    int retCode = QProcess::execute("ll-cli", args);
-    return retCode == 0;
+    qDebug() << "Uninstalling Linglong bundle" << appId << "via script";
+    process.start("pkexec", QStringList{"/usr/libexec/dde-appwiz-linglong-uninstaller.sh", appId});
+    process.waitForFinished();
+    
+    return process.exitCode() == 0;
 }
 
 void postUninstallCleanUp(const QString & desktopId)

--- a/polkit-1/actions/org.deepin.dde.appwiz.uninstall.policy
+++ b/polkit-1/actions/org.deepin.dde.appwiz.uninstall.policy
@@ -12,4 +12,15 @@
     <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/dde-appwiz-uninstaller.sh</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
+  <action id="org.deepin.dde.appwiz.uninstall.linglong">
+    <description>Uninstall a Linglong bundle application</description>
+    <message>Authentication is required to uninstall a Linglong bundle application.</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/dde-appwiz-linglong-uninstaller.sh</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
 </policyconfig>

--- a/polkit-1/rules.d/org.deepin.dde.application-wizard.rules
+++ b/polkit-1/rules.d/org.deepin.dde.application-wizard.rules
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 polkit.addRule(function(action, subject) {
-    if ((action.id == "org.deepin.dde.appwiz.uninstall") &&
+    if ((action.id == "org.deepin.dde.appwiz.uninstall" || 
+         action.id == "org.deepin.dde.appwiz.uninstall.linglong") &&
         subject.active == true && subject.local == true &&
         subject.isInGroup("sudo")) {
             return polkit.Result.YES;

--- a/scripts/dde-appwiz-linglong-uninstaller.sh
+++ b/scripts/dde-appwiz-linglong-uninstaller.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Check if the Linglong App ID is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <linglong_app_id>"
+    exit 1
+fi
+
+LINGLONG_APP_ID="$1"
+
+# Check if ll-cli is available
+if ! command -v ll-cli &> /dev/null; then
+    echo "Error: ll-cli is not available on this system."
+    exit 1
+fi
+
+# Check if the Linglong bundle is installed
+if ! ll-cli list | grep -q "$LINGLONG_APP_ID"; then
+    echo "Error: Linglong bundle '$LINGLONG_APP_ID' is not installed."
+    exit 1
+fi
+
+# Uninstall the Linglong bundle
+if ll-cli uninstall "$LINGLONG_APP_ID"; then
+    echo "Linglong bundle '$LINGLONG_APP_ID' has been successfully uninstalled."
+else
+    echo "Error: Failed to uninstall the Linglong bundle '$LINGLONG_APP_ID'."
+    exit 1
+fi


### PR DESCRIPTION
Added a new script dde-appwiz-linglong-uninstaller.sh for handling Linglong bundle uninstallation with proper error checking and validation Modified uninstallLinglongBundle function to use pkexec with the new script instead of direct ll-cli execution
Updated Polkit policy to include the new script path for proper privilege escalation
Added installation of the new script in CMakeLists.txt This change improves security by using Polkit for privilege escalation and provides better error handling for Linglong uninstallation

feat: 添加玲珑卸载脚本支持

新增 dde-appwiz-linglong-uninstaller.sh 脚本用于处理玲珑包卸载，包含完善 的错误检查和验证
修改 uninstallLinglongBundle 函数使用 pkexec 调用新脚本，替代直接执行 ll-cli
更新 Polkit 策略以包含新脚本路径，实现正确的权限提升
在 CMakeLists.txt 中添加新脚本的安装配置
此改进通过使用 Polkit 进行权限提升提高了安全性，并为玲珑卸载提供了更好的
错误处理

Pms: BUG-291703

## Summary by Sourcery

Introduce a dedicated Linglong bundle uninstaller script invoked through Polkit for secure privilege escalation and improved error handling

New Features:
- Add dde-appwiz-linglong-uninstaller.sh script for handling Linglong bundle uninstallation with validation and error checking

Enhancements:
- Modify uninstallLinglongBundle to invoke the uninstaller via pkexec instead of direct ll-cli calls
- Update Polkit policy to allow privilege escalation for the new Linglong uninstaller script

Build:
- Install the new Linglong uninstaller script via CMakeLists.txt