### PR TITLE
fix: update translation files and add new languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ qt_add_dbus_adaptor(DBUS_ADAPTER_FILES dbus/org.deepin.dde.daemon.Launcher1.xml 
 set(TRANSLATION_FILES
     translations/dde-application-wizard.ts
     translations/dde-application-wizard_bo.ts
+    translations/dde-application-wizard_de.ts
     translations/dde-application-wizard_es.ts
     translations/dde-application-wizard_hu.ts
     translations/dde-application-wizard_it.ts
@@ -47,6 +48,8 @@ set(TRANSLATION_FILES
     translations/dde-application-wizard_pl.ts
     translations/dde-application-wizard_pt_BR.ts
     translations/dde-application-wizard_ru.ts
+    translations/dde-application-wizard_ta.ts
+    translations/dde-application-wizard_tr.ts
     translations/dde-application-wizard_uk.ts
     translations/dde-application-wizard_zh_CN.ts
     translations/dde-application-wizard_zh_TW.ts


### PR DESCRIPTION
1. Added German (de), Tamil (ta), and Turkish (tr) language support to CMakeLists.txt
2. Updated line numbers in all translation files from line 41/43 to 75/77 to reflect source code changes
3. Maintained existing translations while adding new language support
4. This update ensures proper internationalization support and keeps translation files synchronized with source code changes

fix: 更新翻译文件并添加新语言支持

1. 在 CMakeLists.txt 中添加德语、泰米尔语和土耳其语支持
2. 将所有翻译文件中的行号从 41/43 更新为 75/77 以反映源代码变更
3. 保持现有翻译内容同时扩展语言支持范围
4. 此次更新确保正确的国际化支持，并使翻译文件与源代码变更保持同步

Pms: BUG-271635

## Summary by Sourcery

Add support for German, Tamil, and Turkish translations and update existing translation files to match source code changes

New Features:
- Introduce German, Tamil, and Turkish translation files

Enhancements:
- Synchronize message location lines in all translation files from 41/43 to 75/77

Build:
- Update CMakeLists.txt to include the new de, ta, and tr translation files